### PR TITLE
Add FastAPI prototype backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# yatmn_00
-Ttttest
+# Mental Health Counseling App
+
+This repository contains a minimal FastAPI backend demonstrating a prototype mental health counseling service.
+
+## Setup
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+Run the application:
+```bash
+uvicorn app.main:app --reload
+```
+
+This will start a server at `http://127.0.0.1:8000` with API documentation available at `/docs`.
+
+## API Endpoints
+- `POST /users` – create a new user.
+- `GET /therapists` – list available therapists.
+- `POST /appointments` – create an appointment.
+- `GET /appointments` – list appointments.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List, Dict
+
+app = FastAPI(title="Mental Health Counseling API")
+
+class User(BaseModel):
+    id: int
+    name: str
+    email: str
+
+class Therapist(BaseModel):
+    id: int
+    name: str
+    specialty: str
+
+class Appointment(BaseModel):
+    id: int
+    user_id: int
+    therapist_id: int
+    time: str
+
+users: Dict[int, User] = {}
+therapists: Dict[int, Therapist] = {
+    1: Therapist(id=1, name="Dr. Zhang", specialty="Depression"),
+    2: Therapist(id=2, name="Dr. Li", specialty="Anxiety"),
+}
+appointments: Dict[int, Appointment] = {}
+
+@app.post("/users", response_model=User)
+def create_user(user: User):
+    if user.id in users:
+        raise HTTPException(status_code=400, detail="User already exists")
+    users[user.id] = user
+    return user
+
+@app.get("/therapists", response_model=List[Therapist])
+def list_therapists():
+    return list(therapists.values())
+
+@app.post("/appointments", response_model=Appointment)
+def create_appointment(appt: Appointment):
+    if appt.id in appointments:
+        raise HTTPException(status_code=400, detail="Appointment already exists")
+    if appt.user_id not in users:
+        raise HTTPException(status_code=404, detail="User not found")
+    if appt.therapist_id not in therapists:
+        raise HTTPException(status_code=404, detail="Therapist not found")
+    appointments[appt.id] = appt
+    return appt
+
+@app.get("/appointments", response_model=List[Appointment])
+def list_appointments():
+    return list(appointments.values())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx<0.25

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,26 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_create_user_and_list():
+    response = client.post('/users', json={'id': 1, 'name': 'Alice', 'email': 'a@example.com'})
+    assert response.status_code == 200
+    user = response.json()
+    assert user['name'] == 'Alice'
+
+    response = client.get('/therapists')
+    assert response.status_code == 200
+    therapists = response.json()
+    assert len(therapists) >= 2
+
+    response = client.post('/appointments', json={'id': 1, 'user_id': 1, 'therapist_id': 1, 'time': '2024-01-01T10:00'})
+    assert response.status_code == 200
+    appt = response.json()
+    assert appt['user_id'] == 1
+
+    response = client.get('/appointments')
+    assert response.status_code == 200
+    appts = response.json()
+    assert len(appts) == 1


### PR DESCRIPTION
## Summary
- add minimal FastAPI backend implementing simple user, therapist, and appointment APIs
- document setup and endpoints in README
- include requirements file
- add pytest coverage with example test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68413ae9850883319b95c998e80233df